### PR TITLE
default to 80 term width if not a terminal

### DIFF
--- a/main.go
+++ b/main.go
@@ -97,6 +97,10 @@ func truncateWorkflowName(name string, length int) string {
 }
 
 func getTerminalWidth() int {
+	if !term.IsTerminal(int(os.Stdout.Fd())) {
+		return 80
+	}
+
 	width, _, err := term.GetSize(int(os.Stdout.Fd()))
 
 	if err != nil {


### PR DESCRIPTION
closes https://github.com/rsese/gh-actions-status/issues/4

just a band-aid but at least we don't crash if you try to redirect output to a file, `tee`, etc. -- maybe if it's not a terminal just print text instead of using lipgloss 💄 ?