### PR TITLE
no workflow usage API on ghes

### DIFF
--- a/main.go
+++ b/main.go
@@ -430,7 +430,7 @@ func getWorkflows(repoData repositoryData, last time.Duration) ([]*workflow, err
 			}
 		}
 
-		if repoData.Private {
+		if repoData.Private && strings.Index(repoData.HtmlUrl, "https://github.com") == 0 {
 			for _, r := range runs {
 				runTimingPath := fmt.Sprintf("%s/timing", r.URL)
 				stdout, _, err = gh.Exec("api", "--cache", defaultApiCacheTime, runTimingPath, "--jq", ".billable")

--- a/main.go
+++ b/main.go
@@ -144,6 +144,7 @@ func (w *workflow) RenderCard() string {
 }
 
 type repositoryData struct {
+	HtmlUrl   string `json:"html_url"`
 	Name      string `json:"full_name"`
 	Private   bool
 	Workflows []*workflow
@@ -188,9 +189,7 @@ func noTerminalRender(repos []*repositoryData) error {
 		}
 		fmt.Println()
 		fmt.Println(r.Name)
-		// TODO leverage go-gh to determine what host to use
-		// (NB: go-gh needs a PR in order to help with this)
-		fmt.Printf("https://github.com/%s/actions\n", r.Name)
+		fmt.Printf("%s/actions\n", r.HtmlUrl)
 		fmt.Println()
 
 		for _, w := range r.Workflows {
@@ -233,9 +232,7 @@ func terminalRender(repos []*repositoryData) error {
 		}
 		fmt.Println()
 		fmt.Print(repoNameStyle.Render(r.Name))
-		// TODO leverage go-gh to determine what host to use
-		// (NB: go-gh needs a PR in order to help with this)
-		fmt.Print(repoHintStyle.Render(fmt.Sprintf(" https://github.com/%s/actions\n", r.Name)))
+		fmt.Print(repoHintStyle.Render(fmt.Sprintf(" %s/actions\n", r.HtmlUrl)))
 		fmt.Println()
 
 		totalRows := int(math.Ceil(float64(len(r.Workflows)) / float64(cardsPerRow)))


### PR DESCRIPTION
closes #8

poked at the issue and see that on GHES the workflow usage endpoint isn't a thing which led to a 404:

```
could not call gh: failed to run gh. error: exit status 1, stderr: gh: Not Found (HTTP 404)
```

we're already grabbing the repo info and that includes `html_url` which looks like `https://github.com/rsese/gh-actions-status` for a repo on .com but if you're on GHES, it would have a different hostname.  in that case we don't try to call the workflow usage endpoint -- also can use `html_url` when printing out the repo name instead of hardcoding to `github.com`.

I tested on a GHES instance and it worked for me but will wait a bit to merge in case you have time to try it out @stemar94 and confirm you don't see the 404 anymore :v: